### PR TITLE
:rotating_light: Ignore Ansible lint rule `galaxy[no-changelog]`

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 ---
+skip_list:
+  - galaxy[no-changelog]
 exclude_paths:
   - .github/
   - roles/gitlab/molecule


### PR DESCRIPTION
Changelogs are in GitHub releases